### PR TITLE
Log output to stdout only when test property is true

### DIFF
--- a/src/Uecode/Bundle/DaemonBundle/Command/ExtendCommand.php
+++ b/src/Uecode/Bundle/DaemonBundle/Command/ExtendCommand.php
@@ -301,7 +301,7 @@ abstract class ExtendCommand extends ContainerAwareCommand
 
 	protected function log( $content = '', $level = 'info' )
 	{
-		if ( null !== $this->test ) {
+		if ( true === $this->test ) {
 			$this->getOutput()->writeln( $content );
 		}
 		$this->container->get( 'logger' )->$level( $content );


### PR DESCRIPTION
My proposition to log to stdout only when 'test' is true - otherwise it's totally unnecessary in my opinion
