### PR TITLE
Remove leftover that could trigger an error

### DIFF
--- a/src/Uecode/Bundle/DaemonBundle/Command/ReactCommand.php
+++ b/src/Uecode/Bundle/DaemonBundle/Command/ReactCommand.php
@@ -30,14 +30,6 @@ abstract class ReactCommand extends AbstractCommand
     private function initLoop()
     {
         $this->eventLoop = EventLoop\Factory::create();
-        $this->eventLoop->addPeriodicTimer(
-            0.1,
-            function () {
-                $this->runEvents(self::EVENT_CYCLE_START);
-                $this->daemonLogic();
-                $this->runEvents(self::EVENT_CYCLE_END);
-            }
-        );
         $this->prepareLoop($this->eventLoop);
 
         return $this->eventLoop;


### PR DESCRIPTION
I'm sorry for another PR but there was very ugly leftover in ReactCommand that could trigger an error very easily (there was a call to $this->daemonLogic() that's no more required to declare)
